### PR TITLE
fix(ci): Add NX_CLOUD_ACCESS_TOKEN to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
         run: pnpm -F spotify-podcast-automation exec playwright install --with-deps
 
       - name: Run Playwright tests (Nx Affected)
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
         run: pnpm nx affected:test
 
       - name: Run pnpm audit for vulnerabilities


### PR DESCRIPTION
This PR adds the NX_CLOUD_ACCESS_TOKEN to the CI workflow to fix the Nx Cloud workspace connection error. Closes #16